### PR TITLE
fix licence metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,10 +15,5 @@
     "url": "git://github.com/gilmoreorless/css-shorthand-properties.git"
   },
   "main": "index.js",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://gilmoreorless.mit-license.org/"
-    }
-  ]
+  "license": "MIT"
 }


### PR DESCRIPTION
Updating the licence to be compatible with the `package.json` spec
https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license